### PR TITLE
A few bug fixed

### DIFF
--- a/examples/SparkFunGetSetParamTest/SparkFunGetSetParamTest.ino
+++ b/examples/SparkFunGetSetParamTest/SparkFunGetSetParamTest.ino
@@ -24,7 +24,7 @@ void pv(float v) {
 
 void test(float v1, float v2) {
   if (v1 != v2) {
-    Serial.println("!!! " + name + " failed");
+    Serial.println("! ! ! " + name + " failed");
     Serial.println(v1, DEC);
     Serial.println(v2, DEC);
     pass = false;
@@ -33,7 +33,7 @@ void test(float v1, float v2) {
 
 void test(int v1, int v2) {
   if (v1 != v2) {
-    Serial.println("!!! " + name + " failed");
+    Serial.println("! ! ! " + name + " failed");
     Serial.println(v1, DEC);
     Serial.println(v2, DEC);
     pass = false;

--- a/src/SparkFunAutoDriver.cpp
+++ b/src/SparkFunAutoDriver.cpp
@@ -36,6 +36,8 @@ void AutoDriver::SPIConfig()
   
   SPISettings settings(5000000, MSBFIRST, SPI_MODE3); 
  
+  hardHiZ(); //put the bridges in Hi-Z state before the reset.
+  _delay_ms(5);
   
   digitalWrite(_resetPin, LOW);
   _delay_ms(5);

--- a/src/SparkFunAutoDriver.cpp
+++ b/src/SparkFunAutoDriver.cpp
@@ -27,9 +27,6 @@ AutoDriver::AutoDriver(int CSPin, int resetPin)
 
 void AutoDriver::SPIConfig()
 {
-	pinMode(MOSI, OUTPUT);
-	pinMode(MISO, INPUT);
-	pinMode(SCK, OUTPUT);
   pinMode(_CSPin, OUTPUT);
   digitalWrite(_CSPin, HIGH);
   pinMode(_resetPin, OUTPUT);

--- a/src/SparkFunAutoDriver.cpp
+++ b/src/SparkFunAutoDriver.cpp
@@ -33,8 +33,6 @@ void AutoDriver::SPIConfig()
   if (_busyPin != -1) pinMode(_busyPin, INPUT_PULLUP);
  
   SPI.begin();
-  
-  SPISettings settings(5000000, MSBFIRST, SPI_MODE3); 
  
   hardHiZ(); //put the bridges in Hi-Z state before the reset.
   _delay_ms(5);

--- a/src/SparkFunAutoDriver.h
+++ b/src/SparkFunAutoDriver.h
@@ -138,7 +138,7 @@ class AutoDriver
 //    goUntil()
 //    releaseSw()
 #define RESET_ABSPOS  0x00
-#define COPY_ABSPOS   0x01
+#define COPY_ABSPOS   0x08
 
 // configSyncPin() options: the !BUSY/SYNC pin can be configured to be low when
 //  the chip is executing a command, *or* to output a pulse on each full step

--- a/src/SparkFunAutoDriverConfig.cpp
+++ b/src/SparkFunAutoDriverConfig.cpp
@@ -215,15 +215,15 @@ void AutoDriver::setSwitchMode(int switchMode)
 {
   unsigned long configVal = getParam(CONFIG);
   // This bit is CONFIG 4, mask is 0x0010
-  configVal &= ~(0x0100);
+  configVal &= ~(0x010);
   //Now, OR in the masked incoming value.
-  configVal |= (0x0100&switchMode);
+  configVal |= (0x010&switchMode);
   setParam(CONFIG, configVal);
 }
 
 int AutoDriver::getSwitchMode()
 {
-  return (int) (getParam(CONFIG) & 0x0100);
+  return (int) (getParam(CONFIG) & 0x010);
 }
 
 // There are a number of clock options for this chip- it can be configured to


### PR DESCRIPTION
when the ABS_POS register value is copied into the MARK register (ACT = '1'). The bit3 has to be set, (not the bit1). 
