### PR TITLE
improper handling of negative signed integers

### DIFF
--- a/src/SparkFunAutoDriverSupport.cpp
+++ b/src/SparkFunAutoDriverSupport.cpp
@@ -296,7 +296,7 @@ unsigned long AutoDriver::xferParam(unsigned long value, byte bitLen)
   // Let's make sure our value has no spurious bits set, and if the value was too
   //  high, max it out.
   unsigned long mask = 0xffffffff >> (32-bitLen);
-  if (value > mask) value = mask;
+  value &= mask; 
   
   byte* bytePointer = (byte*)&value;
   for (signed char i = byteLen-1; i >= 0; i--)


### PR DESCRIPTION
The deleted line doesn't pass on negatively signed integers properly even if they are within bounds, but have been cast down from a longer bit length.

The change proposed will require that all values exceeding the bounds be checked first before passing to this function, as the upper bits will just be truncated. I believe that most of the functions already do this.
