### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -78,7 +78,7 @@ EXT_32MHZ_OSCOUT_INVERT	LITERAL1
 
 # Public functions
 AutoDriver	KEYWORD2
-SPIPortConnect  KEYWORD2
+SPIPortConnect	KEYWORD2
 busyCheck	KEYWORD2
 getStatus	KEYWORD2
 setParam	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords